### PR TITLE
Add support for named and lazy values

### DIFF
--- a/src/Matrix.php
+++ b/src/Matrix.php
@@ -19,14 +19,19 @@ final class Matrix
 
         foreach (self::recurse($matrix, []) as $result) {
             $key = implode(' ', array_map(
-                fn (mixed $value, int $i) => sprintf(
+                fn (Value $value, int $i) => sprintf(
                     '%s=%s',
                     $names[$i],
-                    json_encode($value),
+                    $value->label,
                 ),
                 $result,
                 array_keys($result),
             ));
+
+            $result = array_map(
+                fn (Value $value) => $value->resolve(),
+                $result,
+            );
 
             yield $key => $result;
         }
@@ -35,7 +40,7 @@ final class Matrix
     /**
      * @param  array<int, mixed>  $matrix
      * @param  array<int, mixed>  $head
-     * @return Generator<int, array<int, mixed>>
+     * @return Generator<int, array<int, Value>>
      */
     private static function recurse(array $matrix, array $head): Generator
     {
@@ -46,6 +51,10 @@ final class Matrix
         }
 
         foreach (array_shift($matrix) as $value) {
+            if (! $value instanceof Value) {
+                $value = Value::wrap($value);
+            }
+
             foreach (self::recurse($matrix, [...$head, $value]) as $result) {
                 yield $result;
             }

--- a/src/MatrixTest.php
+++ b/src/MatrixTest.php
@@ -16,7 +16,7 @@ final class MatrixTest extends TestCase
             'php' => [8.3, 8.4],
             'node' => [
                 Value::of('18', 18),
-                Value::of('20', fn () => 20),
+                Value::of('20', 20),
             ],
             'postgres' => [
                 Value::of('v15', '15.0'),

--- a/src/MatrixTest.php
+++ b/src/MatrixTest.php
@@ -14,19 +14,25 @@ final class MatrixTest extends TestCase
     {
         $result = Matrix::create([
             'php' => [8.3, 8.4],
-            'node' => [18, 20],
-            'postgres' => ['v15', 'v16'],
+            'node' => [
+                Value::of('18', 18),
+                Value::of('20', fn () => 20),
+            ],
+            'postgres' => [
+                Value::of('v15', '15.0'),
+                Value::lazy('v16', fn () => '16.0'),
+            ],
         ]);
 
         $this->assertSame([
-            'php=8.3 node=18 postgres="v15"' => [8.3, 18, 'v15'],
-            'php=8.3 node=18 postgres="v16"' => [8.3, 18, 'v16'],
-            'php=8.3 node=20 postgres="v15"' => [8.3, 20, 'v15'],
-            'php=8.3 node=20 postgres="v16"' => [8.3, 20, 'v16'],
-            'php=8.4 node=18 postgres="v15"' => [8.4, 18, 'v15'],
-            'php=8.4 node=18 postgres="v16"' => [8.4, 18, 'v16'],
-            'php=8.4 node=20 postgres="v15"' => [8.4, 20, 'v15'],
-            'php=8.4 node=20 postgres="v16"' => [8.4, 20, 'v16'],
+            'php=8.3 node=18 postgres=v15' => [8.3, 18, '15.0'],
+            'php=8.3 node=18 postgres=v16' => [8.3, 18, '16.0'],
+            'php=8.3 node=20 postgres=v15' => [8.3, 20, '15.0'],
+            'php=8.3 node=20 postgres=v16' => [8.3, 20, '16.0'],
+            'php=8.4 node=18 postgres=v15' => [8.4, 18, '15.0'],
+            'php=8.4 node=18 postgres=v16' => [8.4, 18, '16.0'],
+            'php=8.4 node=20 postgres=v15' => [8.4, 20, '15.0'],
+            'php=8.4 node=20 postgres=v16' => [8.4, 20, '16.0'],
         ], iterator_to_array($result));
     }
 }

--- a/src/Value.php
+++ b/src/Value.php
@@ -17,9 +17,7 @@ final readonly class Value
     {
         return new self(
             $label,
-            is_callable($value)
-                ? $value(...)
-                : fn () => $value,
+            fn () => $value,
         );
     }
 

--- a/src/Value.php
+++ b/src/Value.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FeatureNinja\TestingMatrix;
+
+use Closure;
+
+final readonly class Value
+{
+    public function __construct(
+        public string $label,
+        public Closure $resolve,
+    ) {}
+
+    public static function of(string $label, mixed $value): self
+    {
+        return new self(
+            $label,
+            is_callable($value)
+                ? $value(...)
+                : fn () => $value,
+        );
+    }
+
+    public static function wrap(mixed $value): self
+    {
+        return self::of(json_encode($value), $value);
+    }
+
+    public static function lazy(string $label, callable $resolve): self
+    {
+        return new self($label, $resolve(...));
+    }
+
+    public function resolve(): mixed
+    {
+        return ($this->resolve)();
+    }
+}


### PR DESCRIPTION
This PR adds support for named and lazy values.

```php
use FeatureNinja\TestingMatrix\Matrix;
use FeatureNinja\TestingMatrix\Value;

Matrix::create([
    'version' => [
        Value::of('8.3', 8.3),
        Value::of('8.4', fn () => 8.3),
    ],
    'data' => [
        Value::lazy('large-file', fn () => file_get_contents('/some/path'),
    ],
])
```